### PR TITLE
fix: remove expect

### DIFF
--- a/src/win.rs
+++ b/src/win.rs
@@ -377,7 +377,7 @@ impl InnerAttributes {
         attrs.lpSecurityDescriptor = unsafe { descriptor.as_ptr() };
         attrs.bInheritHandle = false as i32;
 
-        let acl = Acl::empty().expect("this should never fail");
+        let acl = Acl::empty()?;
 
         Ok(InnerAttributes {
             acl,
@@ -409,7 +409,7 @@ impl InnerAttributes {
         attrs.nLength = mem::size_of::<SECURITY_ATTRIBUTES>() as u32;
         attrs.lpSecurityDescriptor = unsafe { descriptor.as_ptr() };
         attrs.bInheritHandle = false as i32;
-        let acl = Acl::empty().expect("this should never fail");
+        let acl = Acl::empty()?;
         Ok(InnerAttributes {
             descriptor,
             acl,


### PR DESCRIPTION
No `unwrap()` in the production code.

No more `expect()` in the production code.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in ACL initialization to return errors instead of panicking, enhancing application stability when ACL operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->